### PR TITLE
add filter for label text

### DIFF
--- a/src/Crumb.php
+++ b/src/Crumb.php
@@ -89,14 +89,14 @@ class Crumb
             if ($ancestors->isNotEmpty()) {
                 $ancestors->each(function ($item) {
                     $this->add(
-                        get_the_title($item),
+                        $this->getPostTitle($item),
                         get_permalink($item)
                     );
                 });
             }
 
             return $this->add(
-                get_the_title()
+                $this->getPostTitle()
             );
         }
 
@@ -178,12 +178,12 @@ class Crumb
                 );
 
                 return $this->add(
-                    get_the_title()
+                    $this->getPostTitle()
                 );
             }
 
             return $this->add(
-                get_the_title(),
+                $this->getPostTitle(),
                 true
             );
         }
@@ -200,7 +200,19 @@ class Crumb
         }
 
         return $this->add(
-            get_the_title()
+            $this->getPostTitle()
         );
+    }
+
+    /**
+     * Get the post title.
+     *
+     * @uses   get_the_title()
+     * @param  int|WP_Post $post
+     * @return string
+     */
+    private function getPostTitle($post = 0)
+    {
+        return apply_filters('log1x/crumb_label', get_the_title($post), $post);
     }
 }


### PR DESCRIPTION
Allows overriding the breadcrumb labels within a theme (for single pages/posts).

In our use case, a client has pages with long titles down the hierarchy. We added an ACF custom field named `short_title` so a page title like "This a very long title about this cool topic" could have an accompanying short title of "Cool Topic". The latter would be used by the theme where space is limited (ie, breadcrumbs).

This PR adds a `log1x/crumb_label` filter to allow the theme to override the crumb's labels, such as:

```
// (in functions.php)
// Replace the crumb's label when short_title is set for a page/post:
add_filter('log1x/crumb_label', function ($title, $post) {
    return get_field('short_title', $post) ?? $title;
}, 10, 2);
```

Notes:
- Instances of `get_the_title()` are replaced by a new `getPostTitle()` method just to keep things DRY.
- This only handles titles for posts, but maybe it inspires ideas for other views like archives, etc.