### PR TITLE
Prevent Breadcrumbs on 404 pages

### DIFF
--- a/src/Crumb.php
+++ b/src/Crumb.php
@@ -63,7 +63,7 @@ class Crumb
      */
     public function build()
     {
-        if (is_front_page()) {
+        if (is_front_page() || is_404()) {
             return $this->breadcrumb;
         }
 


### PR DESCRIPTION
This fixes the PHP error `Undefined array key 404`. Thought about adding a specific key for that case, but as the content is not found it is obsolete IMO.