### PR TITLE
Fix error for subpages: Attempt to read property "ID" on int

### DIFF
--- a/src/Crumb.php
+++ b/src/Crumb.php
@@ -94,7 +94,7 @@ class Crumb
                     $this->add(
                         get_the_title($item),
                         get_permalink($item),
-                        $item->ID
+                        $item
                     );
                 });
             }


### PR DESCRIPTION
`get_ancestors()` returns IDs here: https://github.com/Log1x/crumb/blob/master/src/Crumb.php#L89

This fixes an `attempt to read property "ID" on int` error.